### PR TITLE
Bug Fixes

### DIFF
--- a/TDSPaster/DataValidation.cs
+++ b/TDSPaster/DataValidation.cs
@@ -1,21 +1,41 @@
-﻿using System.Text.RegularExpressions;
-using System.Windows.Forms;
+﻿using System.IO;
+using System.Text.RegularExpressions;
 
 namespace TDSPaster
 {
     class DataValidation
     {
+        //check to make sure the file is a valid TDS file
+        public static bool IsTdsFile(string fileLocation)
+        {
+            //get the file name without the extension
+            string fileName = Path.GetFileNameWithoutExtension(fileLocation);
+            //get the file path and remove the . in front
+            string path = Path.GetExtension(fileLocation).Replace(".", "");
+            //try to parse the string to see if it is an int
+            int num;
+            bool isNumeric = int.TryParse(path, out num);
+
+            bool isTdsFormat = fileName.Trim().Length == 6;
+            //has numeric file extension and 6 letter file-name
+            if (isNumeric && isTdsFormat)
+            {
+                return true;
+            }
+            //not a TDS file
+            return false;
+        }
+
         //cleaning up the many types of comments that are not TDS compatable
         public static string DataValidator(string readingValue)
         {
             //check to make sure data already contains decimals. If not, continue on with validation. If so, checks and fixes decimal placement (ie data truncated from BEAM).
-            if (readingValue.Contains("."))
+            /*if (readingValue.Contains(".") && readingValue.StartsWith("0"))
             {
                 //This code checks to see if the reading has been truncated and repairs if it has
-                int count = readingValue.Length;
                 decimal floatHolder;
                 //executes if the reading has had just one zero truncated and checks for leading zero beam exports
-                if (readingValue.StartsWith("0") && count == 4)
+                if (readingValue.StartsWith("0") && readingLength == 4)
                 {
                     //adds a zero to the end of the reading by multiplying by the decimal
                     floatHolder = decimal.Parse(readingValue);
@@ -23,13 +43,13 @@ namespace TDSPaster
                     readingValue = floatHolder.ToString();
                 }
                 //executes if the reading has had two zeroes truncated and checks for leading zero beam exports
-                if (readingValue.StartsWith("0") && count == 3)
+                if (readingValue.StartsWith("0") && readingLength == 3)
                 {
                     floatHolder = decimal.Parse(readingValue);
                     floatHolder = floatHolder * 1.00m;
                     readingValue = floatHolder.ToString();
                 }
-            }
+            }*/
 
             char[] charsToTrim = { '.' };//Place any characters that should not go into the TDS file here
 
@@ -37,24 +57,22 @@ namespace TDSPaster
             var tdsComments = "+()/=<>;$[#*@?".ToCharArray();
             //checks if reading value contains comments
             var hasTdsComments = readingValue.IndexOfAny(tdsComments) != -1;
-
             //the following strings encase the numeric value
             string quote = "\"";
             string spaceQuote = " \"";
             string commentQuote = "\"   ";
             string singleZero = "0";
             string doubleZero = "00";
-            int readingLength = readingValue.Length;
-            //check to make sure the reading is between 0 and 4 chars; if not, a blank reading will be entered.
-            bool isValidLength = readingLength <= 4 && readingLength > -1;
-
+            
             //if the data is numbers with a single character the if statement will execute.           
-            if (Regex.IsMatch(readingValue, @"\d") && isValidLength)
+            if (Regex.IsMatch(readingValue, @"\d"))
             {
                 //todo put the trimming functions in their own method
                 readingValue = readingValue.TrimStart('0'); //getting rid of any leading zeros
                 readingValue = readingValue.Trim(charsToTrim);
 
+                int readingLength = readingValue.Length;
+                //check reading length and determine how to format the reading. If it is more than 4 or less than one, a blank reading is returned.
                 switch (readingLength)
                 {
                     case 4:
@@ -69,7 +87,10 @@ namespace TDSPaster
                     case 1:
                         readingValue = quote + doubleZero + readingValue + spaceQuote;
                         break;
-                }
+                    default:
+                        readingValue = @"""    """;
+                        break;
+                }    
             }
             //check if the reading contains TDS comments.
             else if (hasTdsComments)
@@ -78,7 +99,6 @@ namespace TDSPaster
                 readingValue = readingValue.Replace(" ", string.Empty);
                 readingValue = commentQuote + readingValue + quote;
             }
-
             //if the reading is not a valid reading or TDS comment replace reading with a blank reading
             else
             {
@@ -87,7 +107,7 @@ namespace TDSPaster
             return readingValue;
         }
 
-       public static string RemoveNonAlpha(string line)
+        public static string RemoveNonAlpha(string line)
         {
             //Replace all multiple spaces with just one space, then remove the quotes.
             var newLine = Regex.Replace(line, @"\s+", " ");

--- a/TDSPaster/MainForm.cs
+++ b/TDSPaster/MainForm.cs
@@ -179,7 +179,6 @@ namespace TDSPaster
         //Initiates controls enabled / visible state upon start and for re-run
         private void InitControls()
         {
-
             PasteDataButton.Enabled = false;
             SaveFileButton.Enabled = false;
             rowLeftLabel.Visible = false;
@@ -195,28 +194,7 @@ namespace TDSPaster
             dataGridView1.Rows.Clear();
             dataGridView1.Columns.Clear();
         }
-
-        //check to make sure the file is a valid TDS file
-        private bool IsTdsFile(string fileLocation)
-        {
-            //get the file name without the extension
-            string fileName = Path.GetFileNameWithoutExtension(fileLocation);
-            //get the file path and remove the . in front
-            string path = Path.GetExtension(fileLocation).Replace(".", "");
-            //try to parse the string to see if it is an int
-            int num;
-            bool isNumeric = int.TryParse(path, out num);
-
-            bool isTdsFormat = fileName.Trim().Length == 6;
-            //has numeric file extension and 6 letter file-name
-            if (isNumeric && isTdsFormat)
-            {
-                return true;
-            }
-            //not a TDS file
-            return false;
-        }
-
+        
         private void PasteData()
         {
             try
@@ -306,8 +284,8 @@ namespace TDSPaster
 
         private void superSecret()
         {
-            SoundPlayer simpleSound = new SoundPlayer(Properties.Resources.superSecret);
-            simpleSound.Play();
+            SoundPlayer superSecret = new SoundPlayer(Properties.Resources.superSecret);
+            superSecret.Play();
         }
 
         //gathers the information for the elevation you want to write to
@@ -338,7 +316,7 @@ namespace TDSPaster
                     // Open the selected file to read.
                     Stream fileStream = openFileDialog1.OpenFile();
 
-                    using (StreamReader reader = new StreamReader(fileStream))
+                    using (new StreamReader(fileStream))
                     {
                         string filename = openFileDialog1.FileName;
                         _fileLocation = filename;
@@ -346,7 +324,7 @@ namespace TDSPaster
                     fileStream.Close();
 
                     //check to make sure that the file path is not null and that the file is a valid TDS file
-                    if (_fileLocation != null && IsTdsFile(_fileLocation))
+                    if (_fileLocation != null && DataValidation.IsTdsFile(_fileLocation))
                     {
                         PasteDataButton.Enabled = true;
 
@@ -358,11 +336,10 @@ namespace TDSPaster
                         {
                             counter++;
                         }
-                        int finalTubeCount = (counter - 18) / 3;
-                        _tubeCount = finalTubeCount;
+                        _tubeCount = (counter - 18) / 3;
                         reader3.Close();
 
-                        StreamReader reader2 = new StreamReader(_fileLocation);
+                    StreamReader reader2 = new StreamReader(_fileLocation);
                         counter = 0;
 
                         //This is grabbing the informaion about the elevation that has been selected to be overwritten
@@ -385,7 +362,7 @@ namespace TDSPaster
                         elevationInfoListBox.Items.Add("");
                         elevationInfoListBox.Items.Add("Elevation: " + _elevationName1 + _elevationName2 + _elevationName3);
                         elevationInfoListBox.Items.Add("");
-                        elevationInfoListBox.Items.Add("# Tubes:\t" + _tubeCount);//hastag tubes!
+                        elevationInfoListBox.Items.Add("# Tubes:\t" + _tubeCount);//hashtag tubes!
 
                         reader2.Close(); 
                     }
@@ -427,7 +404,7 @@ namespace TDSPaster
                 {
                     //validating that the selected file tube count matches the pasted data, for more info check methods above
                     int tubeCompare = TubeCountComparison();
-                    if (tubeCompare == 2) { string errMSG = ErrMsgTubeCount(tubeCompare); MessageBox.Show(errMSG); return; }
+                    if (tubeCompare == 2) { string errMsg = ErrMsgTubeCount(tubeCompare); MessageBox.Show(errMsg); return; }
                     
                     //creating the array, this is dynamic, the array will match the number of columns and rows
                     string[,] readingValueArray = new string[dataGridView1.Rows.Count, dataGridView1.Columns.Count];


### PR DESCRIPTION
- fixed the bug that was causing reading with a length of more than 4 chars (ie 0.123) to be written as blank readings. Moved the check for reading length to right after the trim. That way, if readingLength > 4 AFTER TRIM, a blank reading is entered.\
- noticed a redundancy in the code. We checked for truncated decimals and put them in there, then immidiately trimmed them out. I have commented this code out for now. If we can find any reason that we need it, we can just uncomment. But for all my tests so far everything is working fine now, including decimal data.
- moved the check to see if the file is a TDS file into the data validation class
